### PR TITLE
Fix errors when file type not found for pattern

### DIFF
--- a/src/tab-loader.js
+++ b/src/tab-loader.js
@@ -38,8 +38,10 @@ function findTab(patternlab, pattern) {
     //look for a custom filetype for this template
     try {
       var tabFileName = path.resolve(customFileTypePath);
+      var tabFileNameStats = null;
       try {
-        var tabFileNameStats = fs.statSync(tabFileName);
+        var _stats = fs.statSync(tabFileName);
+        _stats && (tabFileNameStats = _stats);
       } catch (err) {
         //not a file - move on quietly
       }


### PR DESCRIPTION
I kept getting errors if I didn't define scss or js files for patterns, if I had those types in my `tabsToAdd` option. I think this is a decent fix, but not sure why existing `tabFileNameStats.isFile()` was not preventing the attempt to copy a non-existent file. In this case, `tabFileNameStats` is definitively set to null unless the `fs.statSync` succeeds in the try block.