### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Example:
 }
 ```
 
-Add file extensions to this array as strings. Example: `"tabsToAdd": ['scss', 'js']`. You are all set now.
+Add file extensions to this array as strings. Example: `"tabsToAdd": ["scss", "js"]`. You are all set now.
 
 ## Expected Structure
 


### PR DESCRIPTION
Where is says how to add extensions, line 41, its says to use ['scss', 'js'] but this throws an error in the console, shouldn't it be ["scss", "js"] ?